### PR TITLE
処理中は絶対パス、表示は相対パスにするように修正

### DIFF
--- a/src/pycodemetrics/cli/analyze_python_metrics.py
+++ b/src/pycodemetrics/cli/analyze_python_metrics.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pandas as pd
 import tabulate
@@ -12,8 +13,10 @@ from pycodemetrics.services.analyze_python_metrics import (
 
 logger = logging.getLogger(__name__)
 
+
 def _get_target_files(repo_path: str) -> list[str]:
     return [f for f in list_git_files(repo_path) if f.endswith(".py")]
+
 
 def _analyze_python_metrics(target_file_paths: list[str]) -> list[PythonFileMetrics]:
     results = []
@@ -30,13 +33,23 @@ def _analyze_python_metrics(target_file_paths: list[str]) -> list[PythonFileMetr
             continue
     return results
 
+
 def _transform_for_display(results: list[PythonFileMetrics]) -> pd.DataFrame:
     results_flat = [result.to_flat() for result in results]
     return pd.DataFrame(results_flat, columns=results_flat[0].keys())
 
+
 def run_analyze_python_metrics(repo_path: str):
     target_file_paths = _get_target_files(repo_path)
-    results = _analyze_python_metrics(target_file_paths)
+    if len(target_file_paths) == 0:
+        logger.warning("No python files found in the repository")
+        return
+    target_file_full_paths = [os.path.join(repo_path, f) for f in target_file_paths]
+    results = _analyze_python_metrics(target_file_full_paths)
+
     results_df = _transform_for_display(results)
-    result_table = tabulate.tabulate(results_df, headers="keys") #type: ignore
+    results_df["filepath"] = results_df["filepath"].map(
+        lambda x: os.path.relpath(x, repo_path)
+    )
+    result_table = tabulate.tabulate(results_df, headers="keys")  # type: ignore
     print(result_table)


### PR DESCRIPTION
## 概要
- 処理中は絶対パス、表示は相対パスにするように修正

## 関連Issue
- なし

## 変更内容
- 変更内容を箇条書きで記載してください。
  - Pythonファイルの解析を行う場合は、repo_dirと対象ファイルのパスをつなげて絶対パスにしたものを処理するようにした
  - 表形式で表示する場合には、repo_dir部分を除外するように相対パスにするようにした

