### PR TITLE
pre-commit-configのmypy設定を戻した。そして対象ファイルをコミットしたファイルだけじゃなくした

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,20 @@ repos:
         require_serial: true
         additional_dependencies: []
         minimum_pre_commit_version: "2.9.2"
-
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.0
+    hooks:
+      # Run the mypy.
+      - id: mypy
+        name: mypy
+        description: "Run 'mypy' for Python linting"
+        entry: mypy
+        language: python
+        args: [--ignore-missing-imports]
+        require_serial: true
+        pass_filenames: false
+        additional_dependencies: []
+        minimum_pre_commit_version: '2.9.2'
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:


### PR DESCRIPTION
## 概要
- pre-commit-configのmypy設定を戻した。
- 対象ファイルをコミットしたファイルだけじゃなくした

