### PR TITLE
renovateでpre-commit-configも見てもらるように設定変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,8 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
-  ]
+  ],
+  "pre-commit": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
## 概要
- renovateの設定ファイルで、pre-commigの設定をenableにした

