### PR TITLE
chore: PRタイトルをチェックするGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,19 @@
+name: Check PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
- PRタイトルを形式的にすることでRelease Noteの作成のための情報を構造化する

## 変更内容
- chore: PRタイトルをチェックするGitHub Actionsワークフローを追加
