### PR TITLE
feat: Add universal exclude patterns for all commands

### DIFF
--- a/src/pycodemetrics/cli/analyze_committer/handler.py
+++ b/src/pycodemetrics/cli/analyze_committer/handler.py
@@ -273,7 +273,10 @@ def run_analyze_committer_metrics(
     export_param: ExportParameter,
 ) -> None:
     # パラメータの処理
-    target_file_paths = get_target_files_by_git_ls_files(input_param.path)
+    exclude_patterns = ConfigManager.get_exclude_patterns(input_param.config_file_path)
+    target_file_paths = get_target_files_by_git_ls_files(
+        input_param.path, exclude_patterns
+    )
 
     if len(target_file_paths) == 0:
         logger.warning("No python files found in the specified path.")

--- a/src/pycodemetrics/cli/analyze_hotspot/handler.py
+++ b/src/pycodemetrics/cli/analyze_hotspot/handler.py
@@ -273,7 +273,10 @@ def run_analyze_hotspot_metrics(
     """
 
     # パラメータの処理
-    target_file_paths = get_target_files_by_git_ls_files(input_param.path)
+    exclude_patterns = ConfigManager.get_exclude_patterns(input_param.config_file_path)
+    target_file_paths = get_target_files_by_git_ls_files(
+        input_param.path, exclude_patterns
+    )
 
     if len(target_file_paths) == 0:
         logger.warning("No python files found in the specified path.")

--- a/src/pycodemetrics/cli/analyze_python/handler.py
+++ b/src/pycodemetrics/cli/analyze_python/handler.py
@@ -332,12 +332,15 @@ def run_analyze_python_metrics(
         None
     """
     # パラメータの解釈
+    exclude_patterns = ConfigManager.get_exclude_patterns(input_param.config_file_path)
     base_path = None
     if input_param.with_git_repo:
-        target_file_paths = get_target_files_by_git_ls_files(input_param.path)
+        target_file_paths = get_target_files_by_git_ls_files(
+            input_param.path, exclude_patterns
+        )
         base_path = input_param.path
     else:
-        target_file_paths = get_target_files_by_path(input_param.path)
+        target_file_paths = get_target_files_by_path(input_param.path, exclude_patterns)
         target_file_full_paths = [f for f in target_file_paths]
 
     if len(target_file_paths) == 0:

--- a/src/pycodemetrics/config/config_manager.py
+++ b/src/pycodemetrics/config/config_manager.py
@@ -19,6 +19,21 @@ class UserGroupConfig(BaseModel, extra="forbid"):
 
 TESTCODE_PATTERN_DEFAULT: list[str] = ["*/tests/*.*", "*/tests/*/*.*", "tests/*.*"]
 USER_GROUPS_DEFAULT: list[UserGroupConfig] = []
+EXCLUDE_PATTERN_DEFAULT: list[str] = [
+    "__pycache__",
+    ".git",
+    ".pytest_cache",
+    "node_modules",
+    ".venv",
+    "venv",
+    "env",
+    "ENV",
+    ".env",
+    "site-packages",
+    "dist",
+    "build",
+    ".tox",
+]
 
 
 class ConfigManager:
@@ -50,6 +65,22 @@ class ConfigManager:
             ]
         except KeyError:
             return USER_GROUPS_DEFAULT
+
+    @classmethod
+    def _load_exclude_pattern(cls, pyproject_toml: dict) -> list[str]:
+        """
+        Load the exclude pattern from the pyproject.toml file.
+
+        Args:
+            pyproject_toml (dict): The pyproject.toml file.
+
+        Returns:
+            list[str]: The exclude pattern.
+        """
+        try:
+            return pyproject_toml["tool"]["pycodemetrics"]["exclude"]["pattern"]
+        except KeyError:
+            return EXCLUDE_PATTERN_DEFAULT
 
     @classmethod
     def _load_testcode_pattern(cls, pyproject_toml: dict) -> list[str]:
@@ -103,6 +134,23 @@ class ConfigManager:
             return cls._load_testcode_pattern(pyproject_toml)
         except FileNotFoundError:
             return TESTCODE_PATTERN_DEFAULT
+
+    @classmethod
+    def get_exclude_patterns(cls, config_file_path: Path) -> list[str]:
+        """
+        Get the exclude patterns.
+
+        Args:
+            config_file_path (Path): The path to the configuration file.
+
+        Returns:
+            list[str]: The exclude patterns.
+        """
+        try:
+            pyproject_toml = cls._load(config_file_path)
+            return cls._load_exclude_pattern(pyproject_toml)
+        except FileNotFoundError:
+            return EXCLUDE_PATTERN_DEFAULT
 
     @classmethod
     def get_user_groups(cls, config_file_path: Path) -> list[UserGroupConfig]:

--- a/tests/pycodemetrics/config/test_config_manager.py
+++ b/tests/pycodemetrics/config/test_config_manager.py
@@ -1,0 +1,183 @@
+"""Tests for config_manager module."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import toml
+
+from pycodemetrics.config.config_manager import (
+    EXCLUDE_PATTERN_DEFAULT,
+    TESTCODE_PATTERN_DEFAULT,
+    USER_GROUPS_DEFAULT,
+    ConfigManager,
+    UserGroupConfig,
+)
+
+
+class TestConfigManager:
+    """Test cases for ConfigManager class."""
+
+    def test_get_testcode_type_patterns_with_valid_config(self):
+        """Test get_testcode_type_patterns with valid config file."""
+        config_data = {
+            "tool": {
+                "pycodemetrics": {
+                    "groups": {"testcode": {"pattern": ["custom/tests/*", "spec/*"]}}
+                }
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            toml.dump(config_data, f)
+            config_path = Path(f.name)
+
+        try:
+            patterns = ConfigManager.get_testcode_type_patterns(config_path)
+            assert patterns == ["custom/tests/*", "spec/*"]
+        finally:
+            config_path.unlink()
+
+    def test_get_testcode_type_patterns_with_nonexistent_config(self):
+        """Test get_testcode_type_patterns with non-existent config file."""
+        non_existent_path = Path("/tmp/non_existent_config.toml")
+        patterns = ConfigManager.get_testcode_type_patterns(non_existent_path)
+        assert patterns == TESTCODE_PATTERN_DEFAULT
+
+    def test_get_testcode_type_patterns_with_missing_key(self):
+        """Test get_testcode_type_patterns with config missing the testcode key."""
+        config_data = {"tool": {"pycodemetrics": {"groups": {}}}}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            toml.dump(config_data, f)
+            config_path = Path(f.name)
+
+        try:
+            patterns = ConfigManager.get_testcode_type_patterns(config_path)
+            assert patterns == TESTCODE_PATTERN_DEFAULT
+        finally:
+            config_path.unlink()
+
+    def test_get_user_groups_with_valid_config(self):
+        """Test get_user_groups with valid config file."""
+        config_data = {
+            "tool": {
+                "pycodemetrics": {
+                    "groups": {
+                        "user": {
+                            "frontend": ["src/frontend/*", "web/*"],
+                            "backend": ["src/backend/*", "api/*"],
+                        }
+                    }
+                }
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            toml.dump(config_data, f)
+            config_path = Path(f.name)
+
+        try:
+            user_groups = ConfigManager.get_user_groups(config_path)
+            assert len(user_groups) == 2
+
+            frontend_group = next(g for g in user_groups if g.name == "frontend")
+            assert frontend_group.patterns == ["src/frontend/*", "web/*"]
+
+            backend_group = next(g for g in user_groups if g.name == "backend")
+            assert backend_group.patterns == ["src/backend/*", "api/*"]
+        finally:
+            config_path.unlink()
+
+    def test_get_user_groups_with_nonexistent_config(self):
+        """Test get_user_groups with non-existent config file."""
+        non_existent_path = Path("/tmp/non_existent_config.toml")
+        user_groups = ConfigManager.get_user_groups(non_existent_path)
+        assert user_groups == USER_GROUPS_DEFAULT
+
+    def test_get_user_groups_with_missing_key(self):
+        """Test get_user_groups with config missing the user groups key."""
+        config_data = {"tool": {"pycodemetrics": {"groups": {}}}}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            toml.dump(config_data, f)
+            config_path = Path(f.name)
+
+        try:
+            user_groups = ConfigManager.get_user_groups(config_path)
+            assert user_groups == USER_GROUPS_DEFAULT
+        finally:
+            config_path.unlink()
+
+    def test_get_exclude_patterns_with_valid_config(self):
+        """Test get_exclude_patterns with valid config file."""
+        config_data = {
+            "tool": {
+                "pycodemetrics": {
+                    "exclude": {"pattern": ["custom_exclude/*", "temp/*", ".custom"]}
+                }
+            }
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            toml.dump(config_data, f)
+            config_path = Path(f.name)
+
+        try:
+            patterns = ConfigManager.get_exclude_patterns(config_path)
+            assert patterns == ["custom_exclude/*", "temp/*", ".custom"]
+        finally:
+            config_path.unlink()
+
+    def test_get_exclude_patterns_with_nonexistent_config(self):
+        """Test get_exclude_patterns with non-existent config file."""
+        non_existent_path = Path("/tmp/non_existent_config.toml")
+        patterns = ConfigManager.get_exclude_patterns(non_existent_path)
+        assert patterns == EXCLUDE_PATTERN_DEFAULT
+
+    def test_get_exclude_patterns_with_missing_key(self):
+        """Test get_exclude_patterns with config missing the exclude key."""
+        config_data = {"tool": {"pycodemetrics": {}}}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            toml.dump(config_data, f)
+            config_path = Path(f.name)
+
+        try:
+            patterns = ConfigManager.get_exclude_patterns(config_path)
+            assert patterns == EXCLUDE_PATTERN_DEFAULT
+        finally:
+            config_path.unlink()
+
+    def test_get_exclude_patterns_default_values(self):
+        """Test that EXCLUDE_PATTERN_DEFAULT contains expected patterns."""
+        assert "__pycache__" in EXCLUDE_PATTERN_DEFAULT
+        assert ".git" in EXCLUDE_PATTERN_DEFAULT
+        assert ".venv" in EXCLUDE_PATTERN_DEFAULT
+        assert "venv" in EXCLUDE_PATTERN_DEFAULT
+        assert "env" in EXCLUDE_PATTERN_DEFAULT
+        assert "ENV" in EXCLUDE_PATTERN_DEFAULT
+        assert ".env" in EXCLUDE_PATTERN_DEFAULT
+        assert "node_modules" in EXCLUDE_PATTERN_DEFAULT
+        assert ".pytest_cache" in EXCLUDE_PATTERN_DEFAULT
+        assert "site-packages" in EXCLUDE_PATTERN_DEFAULT
+        assert "dist" in EXCLUDE_PATTERN_DEFAULT
+        assert "build" in EXCLUDE_PATTERN_DEFAULT
+        assert ".tox" in EXCLUDE_PATTERN_DEFAULT
+
+
+class TestUserGroupConfig:
+    """Test cases for UserGroupConfig class."""
+
+    def test_user_group_config_creation(self):
+        """Test UserGroupConfig creation with valid data."""
+        config = UserGroupConfig(name="test_group", patterns=["src/test/*", "tests/*"])
+        assert config.name == "test_group"
+        assert config.patterns == ["src/test/*", "tests/*"]
+
+    def test_user_group_config_forbid_extra_fields(self):
+        """Test that UserGroupConfig forbids extra fields."""
+        with pytest.raises(ValueError):
+            UserGroupConfig(
+                name="test_group", patterns=["src/test/*"], extra_field="not_allowed"
+            )

--- a/tests/pycodemetrics/util/test_file_util.py
+++ b/tests/pycodemetrics/util/test_file_util.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from pycodemetrics.util.file_util import (
+    _is_excluded,
     get_target_files_by_git_ls_files,
     get_target_files_by_path,
 )
@@ -82,3 +83,141 @@ def test_get_target_files_by_git_ls_files(mocker):
 
     # Assert
     assert result == [Path("file1.py"), Path("file3.py"), Path("file4.py")]
+
+
+class TestIsExcluded:
+    """Test cases for _is_excluded function."""
+
+    def test_is_excluded_with_exact_match(self):
+        """Test _is_excluded with exact filename match."""
+        filepath = Path("/src/project/.venv/lib/python.py")
+        exclude_patterns = [".venv"]
+        assert _is_excluded(filepath, exclude_patterns) is True
+
+    def test_is_excluded_with_glob_pattern(self):
+        """Test _is_excluded with glob pattern matching."""
+        filepath = Path("/src/project/__pycache__/module.pyc")
+        exclude_patterns = ["__pycache__"]
+        assert _is_excluded(filepath, exclude_patterns) is True
+
+    def test_is_excluded_with_wildcard_pattern(self):
+        """Test _is_excluded with wildcard pattern."""
+        filepath = Path("/src/project/build/output.py")
+        exclude_patterns = ["build"]
+        assert _is_excluded(filepath, exclude_patterns) is True
+
+    def test_is_excluded_with_multiple_patterns(self):
+        """Test _is_excluded with multiple exclude patterns."""
+        filepath = Path("/src/project/node_modules/package.py")
+        exclude_patterns = [".venv", "node_modules", "__pycache__"]
+        assert _is_excluded(filepath, exclude_patterns) is True
+
+    def test_is_excluded_not_matched(self):
+        """Test _is_excluded returns False when no patterns match."""
+        filepath = Path("/src/project/main.py")
+        exclude_patterns = [".venv", "node_modules", "__pycache__"]
+        assert _is_excluded(filepath, exclude_patterns) is False
+
+    def test_is_excluded_empty_patterns(self):
+        """Test _is_excluded with empty exclude patterns."""
+        filepath = Path("/src/project/main.py")
+        exclude_patterns = []
+        assert _is_excluded(filepath, exclude_patterns) is False
+
+    def test_is_excluded_with_nested_path(self):
+        """Test _is_excluded with deeply nested paths."""
+        filepath = Path("/src/project/.venv/lib/python3.10/site-packages/module.py")
+        exclude_patterns = [".venv"]
+        assert _is_excluded(filepath, exclude_patterns) is True
+
+    def test_is_excluded_case_sensitive(self):
+        """Test _is_excluded is case sensitive."""
+        filepath = Path("/src/project/ENV/bin/python.py")
+        exclude_patterns = ["env"]  # lowercase
+        assert _is_excluded(filepath, exclude_patterns) is False
+
+        exclude_patterns = ["ENV"]  # uppercase
+        assert _is_excluded(filepath, exclude_patterns) is True
+
+
+class TestGetTargetFilesWithExclusion:
+    """Test cases for file targeting functions with exclusion patterns."""
+
+    def test_get_target_files_by_path_with_exclusion(self, tmpdir):
+        """Test get_target_files_by_path with exclusion patterns."""
+        # Arrange
+        tmpdir = Path(tmpdir)
+
+        # Create directory structure
+        venv_dir = tmpdir / ".venv" / "lib"
+        venv_dir.mkdir(parents=True)
+        cache_dir = tmpdir / "__pycache__"
+        cache_dir.mkdir()
+        src_dir = tmpdir / "src"
+        src_dir.mkdir()
+
+        # Create files
+        (venv_dir / "excluded.py").touch()
+        (cache_dir / "cached.py").touch()
+        (src_dir / "main.py").touch()
+        (tmpdir / "app.py").touch()
+
+        # Act
+        exclude_patterns = [".venv", "__pycache__"]
+        result = get_target_files_by_path(tmpdir, exclude_patterns)
+
+        # Assert
+        expected_files = [src_dir / "main.py", tmpdir / "app.py"]
+        assert sorted(result) == sorted(expected_files)
+
+    def test_get_target_files_by_path_no_exclusion(self, tmpdir):
+        """Test get_target_files_by_path without exclusion patterns."""
+        # Arrange
+        tmpdir = Path(tmpdir)
+        subdir = tmpdir / "subdir"
+        subdir.mkdir()
+        (subdir / "test1.py").touch()
+        (subdir / "test2.py").touch()
+
+        # Act
+        result = get_target_files_by_path(tmpdir, None)
+
+        # Assert
+        expected_files = [subdir / "test1.py", subdir / "test2.py"]
+        assert sorted(result) == sorted(expected_files)
+
+    def test_get_target_files_by_path_exclude_single_file(self, tmpdir):
+        """Test get_target_files_by_path excludes single file when matched."""
+        # Arrange
+        tmpdir = Path(tmpdir)
+        venv_file = tmpdir / ".venv" / "script.py"
+        venv_file.parent.mkdir()
+        venv_file.touch()
+
+        # Act
+        exclude_patterns = [".venv"]
+        result = get_target_files_by_path(venv_file, exclude_patterns)
+
+        # Assert
+        assert result == []
+
+    def test_get_target_files_by_git_ls_files_with_exclusion(self, mocker):
+        """Test get_target_files_by_git_ls_files with exclusion patterns."""
+        # Arrange
+        mocker.patch(
+            "pycodemetrics.util.file_util.list_git_files",
+            return_value=[
+                Path("src/main.py"),
+                Path(".venv/lib/module.py"),
+                Path("__pycache__/cached.py"),
+                Path("tests/test_main.py"),
+            ],
+        )
+
+        # Act
+        exclude_patterns = [".venv", "__pycache__"]
+        result = get_target_files_by_git_ls_files(Path("repo"), exclude_patterns)
+
+        # Assert
+        expected_files = [Path("src/main.py"), Path("tests/test_main.py")]
+        assert sorted(result) == sorted(expected_files)


### PR DESCRIPTION
## Summary
- Add default exclude patterns (`.venv`, `__pycache__`, `node_modules`, etc.) to all analysis commands
- Implement configurable exclude patterns via `pyproject.toml`
- Apply exclude functionality uniformly across `analyze`, `hotspot`, and `committer` commands

## Test plan
- [x] All existing tests pass (131 tests)
- [x] New comprehensive test coverage for exclude functionality
- [x] Test coverage improved: `config_manager.py` 86% → 100%, `file_util.py` 92% → 95%
- [x] Manual testing confirms `.venv` directories are excluded from analysis
- [x] Code quality checks pass (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.ai/code)